### PR TITLE
Added Deletion Protection to Podcast Categories

### DIFF
--- a/node/wags-media-repository-api/src/models/podcast.ts
+++ b/node/wags-media-repository-api/src/models/podcast.ts
@@ -2,6 +2,7 @@ export type PodcastCategory = {
     podcastCategoryId: number;
     name: string;
     colorCode: string;
+    podcastCount?: number;
 }
 
 export type Podcast = {

--- a/node/wags-media-repository-api/src/podcasts/lib/PodcastRepository.ts
+++ b/node/wags-media-repository-api/src/podcasts/lib/PodcastRepository.ts
@@ -145,6 +145,7 @@ class PodcastRepository {
 					podcastCategoryId: row.PodcastCategoryId,
 					name: row.Name,
 					colorCode: row.ColorCode,
+					podcastCount: row.PodcastCount,
 				});
 			});
 
@@ -170,6 +171,7 @@ class PodcastRepository {
 				podcastCategoryId: row.PodcastCategoryId,
 				name: row.Name,
 				colorCode: row.ColorCode,
+				podcastCount: row.PodcastCount,
 			});
 		});
 	};

--- a/node/wags-media-repository-api/src/podcasts/lib/queries.ts
+++ b/node/wags-media-repository-api/src/podcasts/lib/queries.ts
@@ -44,18 +44,20 @@ export const deletePodcast = `DELETE FROM Podcast WHERE PodcastId = ?;`;
 
 export const getPodcastCategories = `
 SELECT
-	PodcastCategoryId,
-	Name,
-	ColorCode
-FROM PodcastCategory
+	PC.PodcastCategoryId,
+	PC.Name,
+	PC.ColorCode,
+	(SELECT COUNT(PodcastId) FROM Podcast WHERE  PodcastCategoryId = PC.PodcastCategoryId) AS PodcastCount
+FROM PodcastCategory PC
 ORDER BY Name ASC;
 `;
 
 export const getPodcastCategoryById = `
 SELECT
-    PodcastCategoryId,
-	Name,
-	ColorCode
+    PC.PodcastCategoryId,
+	PC.Name,
+	PC.ColorCode,
+	(SELECT COUNT(PodcastId) FROM Podcast WHERE  PodcastCategoryId = PC.PodcastCategoryId) AS PodcastCount
 FROM PodcastCategory
 WHERE PodcastCategoryId = ?
 `;
@@ -88,4 +90,5 @@ export type PodcastCategoryQueryReturn = {
     PodcastCategoryId: number;
     Name: string;
     ColorCode: string;
+    PodcastCount: number;
 }

--- a/node/wags-media-repository-web/src/models/Podcast.ts
+++ b/node/wags-media-repository-web/src/models/Podcast.ts
@@ -2,6 +2,7 @@ export type PodcastCategory = {
     podcastCategoryId: number;
     name: string;
     colorCode: string;
+    podcastCount: number;
 }
 
 export type Podcast = {

--- a/node/wags-media-repository-web/src/pages/podcasts/PodcastCategories.tsx
+++ b/node/wags-media-repository-web/src/pages/podcasts/PodcastCategories.tsx
@@ -8,6 +8,7 @@ import {
     Spin,
     Table,
     TableProps,
+    Tooltip,
     Typography
 } from 'antd';
 
@@ -86,17 +87,29 @@ const PodcastCategories = (): JSX.Element => {
                     >
                         Edit
                     </Button>
-                    <Confirmation
-                        text={`Are you sure you want to delete '${category.name}'`}
-                        onConfirm={() => deletePodcastCategory(category.podcastCategoryId)}
-                    >
-                        <Button
-                            type="link"
-                            htmlType="button"
+                    {category.podcastCount > 0 ? (
+                        <Tooltip placement="top" title={`${category.name} cannot be deleted as it has ${category.podcastCount} podcast(s) assigned to it.`}>
+                            <Button
+                                type="link"
+                                htmlType="button"
+                                disabled
+                            >
+                                Delete
+                            </Button>
+                        </Tooltip>
+                    ) : (
+                        <Confirmation
+                            text={`Are you sure you want to delete '${category.name}'`}
+                            onConfirm={() => deletePodcastCategory(category.podcastCategoryId)}
                         >
-                            Delete
-                        </Button>
-                    </Confirmation>
+                            <Button
+                                type="link"
+                                htmlType="button"
+                            >
+                                Delete
+                            </Button>
+                        </Confirmation>
+                    )}
                 </Space>
             )
         }


### PR DESCRIPTION
# Added Deletion Protection to Podcast Categories

## Description

Disabled the ability to delete a podcast category if there are any podcasts assigned to the category. The delete button is disabled and a popup is enabled to indicate why.

## Associated Issue

- #3