### PR TITLE
Hide Sidebar When Navigating

### DIFF
--- a/node/wags-media-repository-web/src/components/base/PageLayout.tsx
+++ b/node/wags-media-repository-web/src/components/base/PageLayout.tsx
@@ -30,8 +30,18 @@ const PageLayout = ({ children }: PageLayoutProps): JSX.Element => {
     const navigate = useNavigate();
     const screens = useBreakpoint();
 
+    const isLargeScreen = screens.lg || screens.xl || screens.xxl;
+
+    useEffect(() => {
+        setSidebarCollapsed(!isLargeScreen);
+    }, [isLargeScreen]);
+
     const navigateToPage = (url: string) => {
         navigate(url);
+
+        if (!isLargeScreen) {
+            setSidebarCollapsed(true);
+        }
     };
 
     const BuildMenu = (): MenuProps['items'] => {
@@ -202,12 +212,6 @@ const PageLayout = ({ children }: PageLayoutProps): JSX.Element => {
 
         return menu;
     }
-
-    const isLargeScreen = screens.lg || screens.xl || screens.xxl;
-
-    useEffect(() => {
-        setSidebarCollapsed(!isLargeScreen);
-    }, [isLargeScreen]);
 
     const getOpenedKeys = (): string[] => {
         const keys: string[] = [];


### PR DESCRIPTION
# Hide Sidebar When Navigating

## Work Done

When navigating via the sidebar, the sidebar will now collapse after the page navigates

## Associated Issue

- Closes #55